### PR TITLE
change Metascrum to "Product Owner Team"

### DIFF
--- a/guide-us-english.tex
+++ b/guide-us-english.tex
@@ -365,24 +365,24 @@ Deployment are to:
 \end{itemize}
 
 \section{Product Owner Cycle}
-\subsection{Coordinating the ``What'' - The MetaScrum}
+\subsection{Coordinating the ``What'' - The Product Owner Team}
 A group of Product Owners who need to coordinate a shared backlog that
-feeds a network of teams are themselves a team called a \textbf{MetaScrum}.
-For each SoS there is an associated MetaScrum. A MetaScrum aligns the
+feeds a network of teams are themselves a team called a \textbf{Product Owner Team}.
+For each SoS there is an associated Product Owner Team which aligns the
 teams' priorities along a single path so that they can coordinate their
 team backlogs and build alignment with stakeholders to support the backlog.
-A team's product owner is accoutable for the composition and prioritization
-of the team backlog and may pull backlog from the shared metascrum backlog
-into the team backlog or generate independent backlog at his or her descretion.
+A team's Product Owner is accountable for the composition and prioritization
+of the team backlog and may pull backlog from the shared Product Owner Team backlog
+into the team backlog or generate independent backlog at his or her discretion.
 
-MetaScrums hold a scaled version of Backlog Refinement, the \textbf{Scaled Backlog Refinement Meeting} 
+Product Owner Teams hold a scaled version of Backlog Refinement, the \textbf{MetaScrum} 
 \begin{itemize}
 \item Each team PO (or proxy) must attend
 \item This event is the forum for Leadership, Stakeholders, or other
 Customers to express their preferences
 \end{itemize}
 This event occurs as often as needed, at least once per Sprint, to ensure a
-Ready backlog. 
+Ready backlog at the Product Owner Team level. 
 
 The main functions of the MetaScrum are to:
 \begin{itemize}
@@ -392,11 +392,10 @@ the organization.
 implementation.
 \item generate a single, prioritized backlog; ensuring that duplication of
 work is avoided.
-\item create a minimally uniform ``Definition of Done'' that applies to all teams in
-the SoS.
-\item eliminate dependencies raised by the SoS.
-\item generate a coordinated Release Plan.
-\item decide upon and monitor metrics that give insight into the product.
+\item create a minimally uniform ``Definition of Done'' that applies to all teams.
+\item eliminate dependencies raised by the teams.
+\item generate a coordinated Roadmap and Release Plan.
+\item decide upon and monitor metrics that give insight into the product and the market.
 \end{itemize}
 MetaScrums, just like SoS's, function as Scrum teams on their own. As such,
 they need to have someone who acts as a SM and keeps the team on track in


### PR DESCRIPTION
To be consistent with Scrum Patterns book change Metascrum to "Product Owner Team" and MetaScrum Backlog Refinement Meeting to "Metascrum".