### PR TITLE
Remove "someone who acts as"

### DIFF
--- a/guide-us-english.tex
+++ b/guide-us-english.tex
@@ -400,7 +400,7 @@ work is avoided.
 \item decide upon and monitor metrics that give insight into the product and the market.
 \end{itemize}
 Product Owner Teams, just like SoS's, function as Scrum teams on their own. As such,
-they need to have someone who acts as a SM and keeps the team on track in
+they need to have a SM and keeps the team on track in
 discussions. They also need a single person who is responsible for coordinating the
 generation of a single Product Backlog for all teams within the Scrum of Scrums.
 This person is designated as the \textbf{Chief Product Owner}.


### PR DESCRIPTION
the need for a SM on the Product Owner Team is necessary so simplifying the statement. Little value in "someone who acts as".