### PR TITLE
Updates to SoS Roles and Events

### DIFF
--- a/guide-us-english.tex
+++ b/guide-us-english.tex
@@ -212,13 +212,14 @@ A set of the teams that need to coordinate in order to deliver value to customer
 
 Roles:
 
-The SoS needs to have all of the skills necessary to deliver a fully integrated potentially shippable Product Increment at the end of every Sprint. (It may need experienced architects, QA Leaders, and other operational skill sets.) 
+The SoS needs to have all of the skills necessary to deliver a fully integrated potentially shippable Product Increment at the end of every Sprint and to facilitate cross-team coordination where necessary. (It may need experienced architects, QA Leaders, members of the Product Ownership Team, and other operational skill sets.) 
 The Scrum Master of the Scrum of Scrums is called the \textbf{Scrum of Scrums Master (SoSM)}.
 
 Events:
 
-The SoSM should facilitate a Backlog Refinement event wherein impediments are identified as ``ready'' to be removed, and the team determines how best to remove them and how they will know when they are ``done.''
-Particular attention should be paid to the SoS Retrospective in which the teams' representatives share any learnings or process improvements that their individual teams have succeeded with, in order to share best practices across the teams within the SoS.  Since the SoS needs to be responsive in real-time to impediments raised by participating teams, at least one representative (usually the team's Scrum Master) of each of the participating teams need to attend a \textbf{Scaled Daily Scrum (SDS)}. The SDS event mirrors the Daily Scrum in that it optimizes the collaboration and performance of the network of teams. Any person or number of people from participating teams may attend as needed.
+The SoSM should facilitate a Backlog Refinement event wherein impediments are identified as ``ready'' to be removed, and the team determines how best to remove them and how they will know when they are ``done.'' These impediment removal backlog items/ artifacts are prioritized for the teams on the same single backlog produced by the Meta Scrum. 
+Particular attention should be paid to the SoS Retrospective in which the teams' representatives share any learnings or process improvements that their individual teams have succeeded with, in order to share best practices across the teams within the SoS.  
+Since the SoS needs to be responsive in real-time to impediments raised by participating teams, at least one representative (usually the team's Scrum Master) of each of the participating teams need to attend a \textbf{Scaled Daily Scrum (SDS)}. The SDS event mirrors the Daily Scrum in that it optimizes the collaboration and performance of the network of teams. Any person or number of people from participating teams may attend as needed.
 
 Additionally, the SDS:
 


### PR DESCRIPTION
Add clarity on purpose to include cross team coordination
Add clarity on Roles to include members of the product owner organization
Add clarity on Events/Artifacts to have impediments added to single product backlog