### PR TITLE
Improved description of SoSM responsibility

### DIFF
--- a/guide-us-english.tex
+++ b/guide-us-english.tex
@@ -246,7 +246,7 @@ joint teams' effort and must:
 \item make an impediment backlog visible to the organization.
 \item remove impediments that the teams cannot address themselves.
 \item facilitate prioritization of impediments, with particular attention to cross-team
-dependencies and the distribution of backlog.
+dependencies and enabling cross-team support (which can also include passing backlog items from one team to another).
 \item improve the efficacy of the Scrum of Scrums.
 \item work closely with the Product Owners to deploy a potentially
 releasable Product Increment at least every Sprint.


### PR DESCRIPTION
"the distribution of backlog" is confusing because that is normally something that is done with the PO role. What is meant here is that backlog may be passed along due to an impediment like one team being overloaded. The description has been changed to reflect the purpose of enabling cross team support and that passing backlog is an example.