### PR TITLE
Updating Text for clarity of SoS and SoS Retrospective

### DIFF
--- a/guide-us-english.tex
+++ b/guide-us-english.tex
@@ -110,7 +110,7 @@ Scrum@Scale helps organizations thrive by supporting a transformational leadersh
 
 \section{Scaled Structure: the Scrum of Scrums}
 
-A set of Scrum Teams that need to coordinate in order to deliver value to customers comprise a \textbf{Scrum of Scrums (SoS)}.  This team is responsible for a fully integrated set of potentially shippable increments of product at the end of every Sprint from all participating teams. A SoS functions as a Release Team and must be able to directly deliver value to customers.
+A set of Scrum Teams that need to coordinate in order to deliver value to customers comprise a \textbf{Scrum of Scrums (SoS)}. Unlike the past usage of the term "SoS" as an event, it refers to a team of teams in the context of Scrum @ Scale. This team is responsible for a fully integrated set of potentially shippable increments of product at the end of every Sprint from all participating teams. A SoS functions as a Release Team and must be able to directly deliver value to customers.
 
 A Scrum of Scrums operates as a Scrum Team with scaled versions of the Scrum roles, events and artifacts. Given the scaled nature of the SoS there are some additional considerations.
 

--- a/guide-us-english.tex
+++ b/guide-us-english.tex
@@ -110,7 +110,7 @@ Scrum@Scale helps organizations thrive by supporting a transformational leadersh
 
 \section{Scaled Structure: the Scrum of Scrums}
 
-A set of Scrum Teams that need to coordinate in order to deliver value to customers comprise a \textbf{Scrum of Scrums (SoS)}. This team is responsible for a fully integrated set of potentially shippable increments of product at the end of every Sprint from all participating teams. A SoS functions as a Release Team and must be able to directly deliver value to customers.
+A set of Scrum Teams that need to coordinate in order to deliver value to customers comprise a \textbf{Scrum of Scrums (SoS)}.  This team is responsible for a fully integrated set of potentially shippable increments of product at the end of every Sprint from all participating teams. A SoS functions as a Release Team and must be able to directly deliver value to customers.
 
 A Scrum of Scrums operates as a Scrum Team with scaled versions of the Scrum roles, events and artifacts. Given the scaled nature of the SoS there are some additional considerations.
 
@@ -194,7 +194,7 @@ Some examples of what might be discussed are:
 
 The SoSM should facilitate the refinement of an impediment backlog wherein impediments are identified as ``ready'' and prioritized to be removed. The teans then determine how best to remove them and how they will know when they are ``done.'' In some cases, impediment resolution may require product development, in which case, involvement from the SoS CPO \& Product Owner Team will be necessary.
 
-Particular attention should be paid to the SoS Retrospective in which the teams' representatives share any learnings or process improvements that their individual teams have succeeded with, in order to share best practices across the teams within the SoS.  
+Particular attention should be paid to the SoS Retrospective in which the teams' representatives share any learnings or process improvements that their individual teams have succeeded with, in order to share best practices across the teams within the SoS. The SoS retrospective should cover the improvements the SoS wishes to implement as well, since they are also a team. 
 
 
 \section{Leadership Teams}


### PR DESCRIPTION
Updated the text for SoS Retrospective Paragraph to include Improvement items as part of Retro 

Highlighted the differentiation of SoS (as used in past) vs in S@S