### PR TITLE
Update guide-de-deutsch.tex - make it compileable again

### DIFF
--- a/translations/de-DE/guide-de-deutsch.tex
+++ b/translations/de-DE/guide-de-deutsch.tex
@@ -13,11 +13,12 @@
 \sectionfont{\color{red}}
 \subsectionfont{\color{red}}
 \usepackage{graphicx}
+\graphicspath{{../../images/}}
 \usepackage{hyperref}
 \usepackage{amssymb}
 \usepackage[style=footnote-dw]{biblatex}
-\bibliography{S@SGuideBib}
-\setlength\bibitemsep{0.5\baselineskip}
+%\bibliography{S@SGuideBib}
+%\setlength\bibitemsep{0.5\baselineskip}
 
 \usepackage{enumitem}
 \setitemize{noitemsep}
@@ -48,7 +49,7 @@ Guide}}}
 % \author{}
 \date{}
 
-
+\sloppy
 \begin{document}
 
 %\tableofcontents
@@ -261,7 +262,7 @@ Der Scrum of Scrums Scrum Master (SoSM) ist für die Auslieferung der gemeinsame
 \subsection{Das SoS skalieren}
 Abhängig von der Größe der Organisation oder Implementierung, kann mehr als ein
 SoS benötigt werden, um ein sehr komplexes Produkt liefern zu können. In diesen
-Fällen kann ein textbf\{Scrum of Scrum of Scrums (SoSoS)} aus mehreren Scrum of Scrums
+Fällen kann ein \textbf{Scrum of Scrum of Scrums (SoSoS)} aus mehreren Scrum of Scrums
 gebildet werden. Das SoSoS ist ein organisches Muster von Scrum Teams, das
 unendlich skalierbar ist. Jedes SoSoS sollte SoSoSMaster und skalierte Versionen
 jedes Artefakts \& Events haben.
@@ -624,7 +625,7 @@ zusammen arbeiten zu lassen.
 
 
 Die agilen Coaches und Trainer, die diese Konzepte bei Amazon, GE, 3M, Toyota,
-Spotify, Maersk, Comcast, AT&T implementiert haben, und viele andere Unternehmen,
+Spotify, Maersk, Comcast, AT\&T implementiert haben, und viele andere Unternehmen,
 die mit Jeff Sutherland zusammengearbeitet haben, waren hilfreich dabei, diese
 Konzepte in zahlreichen Unternehmen in verschiedenen Domänen zu testen.
 
@@ -633,7 +634,7 @@ und Überarbeitung dieses Dokuments.
 
 \pagebreak
 
-\printbibliography
+%\printbibliography
 
 \section{Übersetzung}
 Diesen Guide haben Alisa Stolze und Peter Fischbach im Januar 2018 übersetzt.


### PR DESCRIPTION
In german translation:
    Removed bibliography commands for non existent bib file.
    Escaped special characters.
    Added correct path to images.
    Added 'sloppy' for better word wrap.
    Document now compiles correctly but needs some more teXnical improvements.